### PR TITLE
Version 1.1.8

### DIFF
--- a/STOTool/STOTool/App.xaml.cs
+++ b/STOTool/STOTool/App.xaml.cs
@@ -71,7 +71,7 @@ namespace STOTool
       private void LogException(Exception ex)
       {
           Logger.Critical("ERROR! Unhandled exception!");
-          Logger.Critical($"Exception:\n{ex.Message}\n{ex.StackTrace}");
+          Logger.Critical($"Exception:{ex.Message}\n{ex.StackTrace}");
       }
       
       private void KillExistingInstances()

--- a/STOTool/STOTool/Enum/LogLevel.cs
+++ b/STOTool/STOTool/Enum/LogLevel.cs
@@ -4,10 +4,10 @@
     {
         Critical,
         Fatal,
-        Info,
         Warning,
         Error,
         Trace,
+        Info,
         Debug,
     }
 }

--- a/STOTool/STOTool/Feature/AutoNews.cs
+++ b/STOTool/STOTool/Feature/AutoNews.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using HtmlAgilityPack;
 using Microsoft.Playwright;
 using Newtonsoft.Json;
@@ -20,22 +21,32 @@ namespace STOTool.Feature
         private static async Task<HtmlNodeCollection> GetContentAsync()
         {
             var page = await Helper.Browser.NewPageAsync();
-            await page.GotoAsync(Url, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
-
-            string content = await page.ContentAsync();
-            await page.CloseAsync();
             
-            HtmlDocument htmlDoc = new HtmlDocument();
-            htmlDoc.LoadHtml(content);
-            
-            HtmlNodeCollection newsNodes = htmlDoc.DocumentNode.SelectNodes(NewsXPath);
+            try
+            {
+                await page.GotoAsync(Url, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
 
-            return newsNodes;
+                string content = await page.ContentAsync();
+                await page.CloseAsync();
+
+                HtmlDocument htmlDoc = new HtmlDocument();
+                htmlDoc.LoadHtml(content);
+
+                HtmlNodeCollection newsNodes = htmlDoc.DocumentNode.SelectNodes(NewsXPath);
+
+                return newsNodes;
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e.Message + e.StackTrace);
+                await page.CloseAsync();
+                return null;
+            }
         }
 
         private static string ExtractTitle(HtmlNode htmlNode)
         {
-            string title = htmlNode.SelectSingleNode(".//h3[contains(@class, 'news-page__news-post-title')]")?.InnerText.Trim();
+            string title = HttpUtility.HtmlDecode(htmlNode.SelectSingleNode(".//h3[contains(@class, 'news-page__news-post-title')]")?.InnerText.Trim());
             return title;
         }
         
@@ -63,14 +74,6 @@ namespace STOTool.Feature
             var hashBytes = sha256.ComputeHash(inputBytes);
             return Convert.ToBase64String(hashBytes);
         }
-        
-        private static string GenerateHash(HtmlNode htmlNode)
-        {
-            using var sha256 = SHA256.Create();
-            var inputBytes = Encoding.UTF8.GetBytes(ExtractTitle(htmlNode));
-            var hashBytes = sha256.ComputeHash(inputBytes);
-            return Convert.ToBase64String(hashBytes);
-        }
 
         private static async Task StoreIntoFile(NewsNodes newsData)
         {
@@ -84,6 +87,13 @@ namespace STOTool.Feature
             {
                 Logger.Info("No previous data to compare.");
                 var data = await FetchPageContentAsync();
+
+                if (Helper.NullCheck(data))
+                {
+                    Logger.Debug("Somehow some nodes are null or empty. Write into file canceled.");
+                    return "null";
+                }
+                
                 await StoreIntoFile(data);
                 return "null";
             }
@@ -98,6 +108,8 @@ namespace STOTool.Feature
             }
             else
             {
+                await Cache.RemoveAll();
+                
                 Logger.Info("Data has changed.");
                 var result = await GetNewsImage.CallScreenshot(0);
                 
@@ -113,7 +125,6 @@ namespace STOTool.Feature
             if (result != "null")
             {
                 await StoreIntoFile(currentData);
-                await Cache.RemoveAll();
 
                 Logger.Debug("Due to news has updated, Force refresh all caches.");
                 

--- a/STOTool/STOTool/Feature/Calendar.cs
+++ b/STOTool/STOTool/Feature/Calendar.cs
@@ -15,6 +15,8 @@ namespace STOTool.Feature
 {
     public class Calendar
     {
+        private static readonly string GoogleCalendarId = "uhio1bvtudq50n2qhfeo98iduo@group.calendar.google.com";
+        
         public static async Task<List<EventInfo>>? GetRecentEventsAsync()
         {
             try
@@ -44,7 +46,7 @@ namespace STOTool.Feature
                     ApplicationName = "STO Server Checker"
                 });
 
-                EventsResource.ListRequest request = service.Events.List("uhio1bvtudq50n2qhfeo98iduo@group.calendar.google.com");
+                EventsResource.ListRequest request = service.Events.List(GoogleCalendarId);
                 request.TimeMin = DateTime.UtcNow;
                 request.ShowDeleted = false;
                 request.SingleEvents = true;

--- a/STOTool/STOTool/Feature/WebSocketServer.cs
+++ b/STOTool/STOTool/Feature/WebSocketServer.cs
@@ -62,7 +62,7 @@ namespace STOTool.Feature
             }
         }
 
-        public void Stop()
+        public static void Stop()
         {
             if (_cancellationTokenSource != null)
             {
@@ -83,10 +83,25 @@ namespace STOTool.Feature
 
                 await HandleWebSocketMessages(webSocket);
             }
-            catch (Exception ex)
+            catch (WebSocketException ex)
             {
                 Logger.Error($"WebSocket error: {ex.Message}\n{ex.StackTrace}");
-                webSocketContext?.WebSocket.CloseAsync(WebSocketCloseStatus.InternalServerError, "Internal Server Error", CancellationToken.None);
+                if (ex.InnerException != null)
+                {
+                    Logger.Error($"Inner Exception: {ex.InnerException.Message}\n{ex.InnerException.StackTrace}");
+                }
+                if (webSocketContext?.WebSocket != null)
+                {
+                    await webSocketContext.WebSocket.CloseAsync(WebSocketCloseStatus.InternalServerError, "Internal Server Error", CancellationToken.None);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Unexpected error: {ex.Message}\n{ex.StackTrace}");
+                if (webSocketContext?.WebSocket != null)
+                {
+                    await webSocketContext.WebSocket.CloseAsync(WebSocketCloseStatus.InternalServerError, "Internal Server Error", CancellationToken.None);
+                }
             }
         }
 
@@ -119,6 +134,14 @@ namespace STOTool.Feature
             catch (WebSocketException ex)
             {
                 Logger.Error($"WebSocket error: {ex.Message}\n{ex.StackTrace}");
+                if (ex.InnerException != null)
+                {
+                    Logger.Error($"Inner Exception: {ex.InnerException.Message}\n{ex.InnerException.StackTrace}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Unexpected error: {ex.Message}\n{ex.StackTrace}");
             }
         }
         
@@ -230,17 +253,25 @@ namespace STOTool.Feature
                     await webSocket.SendAsync(new ArraySegment<byte>(resultBytes, 0, resultBytes.Length), WebSocketMessageType.Text, true, CancellationToken.None);
 
                     Logger.Debug("Hash has changed. Sent result to client.");
-
                     return;
                 }
 
                 byte[] returnNull = Encoding.UTF8.GetBytes("null");
-                
+
                 await webSocket.SendAsync(new ArraySegment<byte>(returnNull, 0, returnNull.Length), WebSocketMessageType.Text, true, CancellationToken.None);
             }
-            catch (Exception e)
+            catch (WebSocketException ex)
             {
-                Logger.Error(e.Message + e.StackTrace);
+                Logger.Error($"WebSocket error: {ex.Message}\n{ex.StackTrace}");
+                if (ex.InnerException != null)
+                {
+                    Logger.Error($"Inner Exception: {ex.InnerException.Message}\n{ex.InnerException.StackTrace}");
+                }
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Unexpected error: {ex.Message}\n{ex.StackTrace}");
                 throw;
             }
         }

--- a/STOTool/STOTool/LogWindow.xaml.cs
+++ b/STOTool/STOTool/LogWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using STOTool.Feature;
 using STOTool.Generic;
 
 namespace STOTool
@@ -55,7 +56,14 @@ namespace STOTool
             
             // ev.Cancel = true;
             // this.Hide();
-
+            
+            WebSocketServer.Stop();
+            Logger.Info("WebSocket server has stopped.");
+            
+            Cache.MemoryCache.Dispose();
+            Cache.CancelCacheGuard();
+            Logger.Info("Cache has been disposed.");
+            
             Environment.Exit(0);
         }
     }

--- a/STOTool/STOTool/MainWindow.xaml.cs
+++ b/STOTool/STOTool/MainWindow.xaml.cs
@@ -16,7 +16,7 @@ namespace STOTool
     /// </summary>
     public partial class MainWindow
     {
-        private const string Version = "1.1.6";
+        private const string Version = "1.1.8";
         
         public static FontFamily StFontFamily { get; private set; }
         
@@ -33,13 +33,10 @@ namespace STOTool
             Logger.ClearLogs();
             PreInit();
             
-            /*Logger.Debug("You're in DEBUG mode.");
-            Api.SetProgramLevel(ProgramLevel.Debug);
-            Logger.SetLogLevel(LogLevel.Debug);*/
             LogWindow.Instance.Show();
             Task.Run(PostInit);
 
-            Logger.Info($"Welcome to STOTool. This is version {Version}. If you meet any problem, please contact me at github.");
+            Logger.Info($"Thanks for using STOTool. Current Version: {Version}. If you meet any problem, please contact me at github.");
         }
 
         protected override void OnClosing(CancelEventArgs e)
@@ -55,9 +52,6 @@ namespace STOTool
             {
                 Logger.Info($"Proceeding PostInit phase.");
                 
-                await Helper.InitBrowser();
-
-                // Init the caches in the first time.
                 var cacheNewsTask = Cache.GetCachedNewsAsync();
                 var cacheInfoTask = Cache.GetCachedInfoAsync();
                 var cacheMaintenanceTask = Cache.GetFastCachedMaintenanceInfoAsync();
@@ -65,6 +59,8 @@ namespace STOTool
                 await Task.WhenAll(cacheNewsTask, cacheInfoTask, cacheMaintenanceTask);
                 
                 Logger.Info($"PostInit has completed.");
+                
+                Cache.StartCacheGuard();
 
                 while (true)
                 {
@@ -134,6 +130,10 @@ namespace STOTool
 
                 BackgroundImageDown = backgroundImages[0];
                 BackgroundImageUp = backgroundImages[1];
+                
+                DrawNewsImage.InitFonts();
+                
+                await Helper.InitBrowserAsync();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# General

* Resolved an issue with drawing multiple news items and titles.
* Resolved an issue where the cache's callback would not be called when the cache expired.
* Reformatted the layout.
* Modularized the draw functionality. It is now easier to maintain.
* Resolved an issue where the caller in logs was listed as `Unknown Caller` for most methods.
* Resolved an issue that caused AutoNews to keep spamming.
* Resolved an issue where news titles contained HTML codes.